### PR TITLE
add `as` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Prepend RailsKwargsTesting::ControllerMethods. Supported options are:
 - :params
 - :session
 - :xhr
+- :as
 
 ### Minitest
 

--- a/lib/rails_kwargs_testing/controller_methods.rb
+++ b/lib/rails_kwargs_testing/controller_methods.rb
@@ -8,7 +8,11 @@ module RailsKwargsTesting
       post
       put
     ].each do |method_name|
-      define_method(method_name) do |action, flash: nil, format: nil, params: nil, session: nil, xhr: nil|
+      define_method(method_name) do |action, flash: nil, format: nil, params: nil, session: nil, xhr: nil, as: nil|
+        if as
+          format ||= as
+        end
+
         if format
           params = (params || {}).merge(format: format)
         end
@@ -27,7 +31,7 @@ module RailsKwargsTesting
       xhr
       xml_http_request
     ].each do |method_name|
-      define_method(method_name) do |request_method, action, flash: nil, format: nil, params: nil, session: nil|
+      define_method(method_name) do |request_method, action, flash: nil, format: nil, params: nil, session: nil, as: nil|
         insert_xhr_headers
         __send__(request_method, action, flash: flash, format: format, params: params, session: session).tap do
           reset_xhr_headers

--- a/test/rails_kwargs_testing/controller_methods_test.rb
+++ b/test/rails_kwargs_testing/controller_methods_test.rb
@@ -18,6 +18,11 @@ class ControllerMethodsTest < ActionController::TestCase
     assert_equal "application/json", decoded_body["format"]
   end
 
+  def test_keyword_as
+    post :index, as: :json
+    assert_equal "application/json", decoded_body["format"]
+  end
+
   def test_keyword_params
     post :index, params: { a: 1 }
     assert_equal "1", decoded_body["params"]["a"]


### PR DESCRIPTION
Thanks for this great gem !

In Rails5, controller testing methods have parameter `as`.
https://github.com/rails/rails/blob/5-2-stable/actionpack/lib/action_controller/test_case.rb#L460

We have to set `as: :json` parameter, otherwise data types will be converted to strings in Rails5. 
SEE: https://github.com/rails/rails/issues/26075

So I want to pass `as` for test compatibility with Rails 4 and Rails 5.