### PR TITLE
Add :as option to request methods

### DIFF
--- a/lib/rails_kwargs_testing/request_methods.rb
+++ b/lib/rails_kwargs_testing/request_methods.rb
@@ -12,7 +12,10 @@ module RailsKwargsTesting
       post_via_redirect
       put_via_redirect
     ].each do |method_name|
-      define_method(method_name) do |path, env: {}, headers: {}, params: nil|
+      define_method(method_name) do |path, env: {}, headers: {}, params: nil, as: nil|
+        if as
+          params = (params || {}).merge(format: as)
+        end
         super(path, params, env.merge(headers))
       end
     end

--- a/test/rails_kwargs_testing/request_methods_test.rb
+++ b/test/rails_kwargs_testing/request_methods_test.rb
@@ -3,6 +3,11 @@ require "test_helper"
 class RequestMethodsTest < ActionDispatch::IntegrationTest
   prepend ::RailsKwargsTesting::RequestMethods
 
+  def test_keyword_as
+    post "/", as: :json
+    assert_equal "application/json", decoded_body["format"]
+  end
+
   def test_keyword_env
     post "/", env: { "rack.url_scheme" => "https" }
     assert_equal "https", decoded_body["scheme"]


### PR DESCRIPTION
Request methods in integration test also accept `:as` option.
https://github.com/rails/rails/blob/5-2-stable/actionpack/lib/action_dispatch/testing/integration.rb#L276